### PR TITLE
fix: /posts/new画面のcss

### DIFF
--- a/src/app/posts/new/page.tsx
+++ b/src/app/posts/new/page.tsx
@@ -8,7 +8,6 @@ import {
   Box,
   Card,
   Flex,
-  Heading,
   Input,
   ScrollArea,
   Spacer,
@@ -27,26 +26,30 @@ const NewPost = () => {
   const [isMarkdownView, setIsMarkdownView] = useState(true);
 
   return (
-    <Box p={"md"}>
+    <Box p={"normal"}>
       <Flex>
-        <Box>
-          <Flex pb={"xs"}>
-            <Input type="text" fontSize={"4xl"} placeholder="タイトル" />
+        <Box marginBottom={"sm"}>
+          <Flex pb={"sm"}>
+            <Input
+              type="text"
+              fontSize={"4xl"}
+              width={"3xl"}
+              bgColor={"neutral.50"}
+              placeholder="タイトルを入力してください。"
+            />
           </Flex>
-          <Flex pl={"xs"}>
-            <Heading fontSize={"2xl"} whiteSpace={"nowrap"} p={"xs"}>
-              タグ
-            </Heading>
+          <Flex>
             <Input
               type="text"
               fontSize={"xl"}
-              placeholder="半角スペースで区切る"
+              bgColor={"neutral.50"}
+              placeholder="タグを入力してください。半角スペースで区切る"
             />
           </Flex>
         </Box>
         <Spacer />
         <Box>
-          <Flex>
+          <Flex gap={"md"} marginTop={"xl"} marginInline={"normal"}>
             <CreateSlideInMd />
             <MdSlideToggle
               isMarkdownView={isMarkdownView}
@@ -61,8 +64,15 @@ const NewPost = () => {
             markdownValue={markdownValue}
             setMarkdownValue={setMarkdownValue}
           />
-          <Card w={"50%"}>
-            <Markdown minW={"50%"}>{markdownValue}</Markdown>
+          <Card
+            w={"50%"}
+            bgColor={"whiteAlpha.950"}
+            border={"1px solid #CED4DA"}
+            boxShadow={"0"}
+          >
+            <Markdown minW={"50%"} p={"md"}>
+              {markdownValue}
+            </Markdown>
           </Card>
         </Flex>
       ) : (
@@ -71,8 +81,13 @@ const NewPost = () => {
             markdownValue={marpValue}
             setMarkdownValue={setMarpValue}
           />
-          <Card w={"50%"}>
-            <ScrollArea innerProps={{ as: VStack, gap: "md" }}>
+          <Card
+            w={"50%"}
+            bgColor={"#CED4DA"}
+            border={"1px solid #CED4DA"}
+            boxShadow={"0"}
+          >
+            <ScrollArea innerProps={{ as: VStack, gap: "1px" }}>
               <SlidePreview slide={marpValue}></SlidePreview>
             </ScrollArea>
           </Card>


### PR DESCRIPTION
# やったこと
- タイトル・タグの入力部分のサイズを揃え、背景色を検索バーやタグと同様のnetural.50に変更し、placeholderの文章を変更
- md to slideのボタンをプレビュー画面の上にくっつけ、少し右側に余白をあけた
  - ボタンが押しづらかったため
- プレビュー画面の背景をwhiteAlpha.950に変更し、markdown入力欄と同じ枠線を追加することで、プレビュー欄がわかりやすくした
- プレビュー欄内にpaddingを当てることで、入力欄に左側がピッタリくっついて見づらい点を修正
- slideプレビューの方の背景に枠線と同じ色を当てることでスライド同士の境目をわかりやすくした

# 比較
## before
<img width="720" alt="スクリーンショット 2024-12-01 23 20 36" src="https://github.com/user-attachments/assets/8eff8a13-5532-4759-abc8-a77b24d10db4">


<img width="720" alt="スクリーンショット 2024-12-01 23 20 58" src="https://github.com/user-attachments/assets/ab27d281-581c-4bef-b1f2-3986fa3e3ec4">
7">

<img width="720" alt="スクリーンショット 2024-12-01 23 21 19" src="https://github.com/user-attachments/assets/92f52bd3-115c-452a-a89a-a6c1c4fbcfa9">

## after
<img width="720" alt="スクリーンショット 2024-12-01 23 11 24" src="https://github.com/user-attachments/assets/2685dd60-cc34-4fbc-9299-2382e496cba0">

<img width="720" alt="スクリーンショット 2024-12-01 23 18 09" src="https://github.com/user-attachments/assets/2b1afdd3-a258-4803-b996-b1ffdd2262c5">

<img width="720" alt="スクリーンショット 2024-12-01 23 18 26" src="https://github.com/user-attachments/assets/07dcaadb-a7bf-42dd-b3f3-764acecad484">

