### PR TITLE
#28 ログイン時にJWTをサーバーに送るように修正した。

### DIFF
--- a/src/app/_utils/nextAuth/next-auth-options.ts
+++ b/src/app/_utils/nextAuth/next-auth-options.ts
@@ -1,5 +1,4 @@
 import GoogleProvider from "next-auth/providers/google";
-
 import type { NextAuthOptions } from "next-auth";
 
 export const nextAuthOptions: NextAuthOptions = {
@@ -12,32 +11,20 @@ export const nextAuthOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    jwt: async ({ token, user, account, profile }) => {
-      // 注意: トークンをログ出力してはダメです。
-      console.log("in jwt", { user, token, account, profile });
-
-      if (user) {
-        token.user = user;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const u = user as any;
-        token.role = u.role;
-      }
+    async jwt({ token, account }) {
       if (account) {
+        // Googleログインの場合、トークン情報をカスタムプロパティとして追加
         token.accessToken = account.access_token;
+        token.idToken = account.id_token;
       }
       return token;
     },
-    session: ({ session, token }) => {
-      console.log("in session", { session, token });
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      token.accessToken;
-      return {
-        ...session,
-        user: {
-          ...session.user,
-          role: token.role,
-        },
-      };
+    async session({ session, token }) {
+      // セッションにJWTの情報を追加
+      session.accessToken = token.accessToken; //accessTokenは、Googleログインの場合のみ存在
+      session.idToken = token.idToken;
+      session.sub = token.sub;
+      return session;
     },
   },
 };

--- a/src/app/api/user/user.tsx
+++ b/src/app/api/user/user.tsx
@@ -1,0 +1,26 @@
+import { Session } from "next-auth";
+
+export const postUser = async (session: Session | null) => {
+  const postAPI = process.env.NEXT_PUBLIC_API_URL + "/users";
+  const name = session?.user?.name;
+  const iconUrl = session?.user?.image;
+  const googleId = session?.sub;
+
+  if (session?.idToken) {
+    const res = await fetch(postAPI, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.idToken}`,
+      },
+      body: JSON.stringify({
+        name: name,
+        icon_url: iconUrl,
+        google_id: googleId,
+      }),
+    });
+
+    const data = await res.json();
+    console.log(data);
+  }
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import React from "react";
-import { useEffect } from "react";
-import { redirect } from "next/navigation";
-import { signIn } from "next-auth/react";
-import { useSession } from "next-auth/react";
 import {
   Button,
   ButtonGroup,
@@ -14,15 +9,26 @@ import {
   Icon,
   Spacer,
 } from "@yamada-ui/react";
+import { signIn, useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+import React, { useEffect } from "react";
 import { FcGoogle } from "react-icons/fc";
 import { SiQiita } from "react-icons/si";
+import { postUser } from "../api/user/user";
 
 const LoginPage = () => {
   const { data: session, status } = useSession();
   useEffect(() => {
     // ログイン済みの場合はTOPページにリダイレクト
     if (status === "authenticated") {
+      console.log("login success");
+      postUser(session);
       redirect("/");
+    } else {
+      if (status === "loading") {
+        return console.log("loading");
+      }
+      console.log("login failed");
     }
   }, [session, status]);
 
@@ -32,6 +38,9 @@ const LoginPage = () => {
 
     // ログインに成功したらTOPページにリダイレクト
     if (result) {
+      console.log("login success");
+      postUser(session);
+      console.log("login success");
       redirect("/");
     }
   };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,23 @@
+import "next-auth";
+
+declare module "next-auth" {
+  interface Session extends DefaultSession {
+    accessToken?: string;
+    idToken?: string;
+    sub?: string;
+  }
+
+  interface User extends DefaultUser {
+    accessToken?: string;
+    idToken?: string;
+    sub?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
+    idToken?: string;
+    sub?: string;
+  }
+}


### PR DESCRIPTION
#28 
# やったこと
ログイン時にJWT（ユーザー情報のハッシュ化されたやつ）をサーバーに送り、ユーザー情報があってるかをgoogleに問い合わせる部分の送る所を実装

- NextAuthで使用している、sessio,JWT,Userの型拡張
- apiの送信関数の実装


# どうしたらできるかわからず、残った修正したいポイント
ロードが長すぎ問題。見たところ、layoutの読み込みが長い。多分NextAuthのsessionをとる部分が長い
# その他作業残っているポイント
エラーハンドリングが終わってないです。エラー出てもログインできているので、一旦このまま進めて最後に修正します