### PR TITLE
#5 feat: posts/[post_id]画面の様々な変更

### DIFF
--- a/src/app/_components/favoriteButton/favoriteButton.tsx
+++ b/src/app/_components/favoriteButton/favoriteButton.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Box, HStack, Center } from "@yamada-ui/react";
+import { HeartIcon } from "@yamada-ui/lucide";
+
+type countFavoriteProps = {
+  countFavorite: number;
+};
+
+const FavoriteButton = ({countFavorite}: countFavoriteProps) => {
+  const [isCount, setIsCount] = useState(false);
+  const [count, setCount] = useState(countFavorite);
+
+  const handleClick = () => {
+    console.log(isCount);
+    if(isCount === false){
+      setCount(count + 1);
+      setIsCount(true);
+      console.log(isCount);
+    }else{
+      setCount(count - 1);
+      setIsCount(false);
+    }
+  };
+
+  return (
+    <Box>
+      <HStack onClick={handleClick} gap={"xs"}>
+        <Box>
+          <HeartIcon
+          bgColor={isCount ? "pink.500" : "whiteAlpha.950"}
+          border={"solid"}
+          borderRadius={"60%"}
+          w={"7xs"}
+          h={"7xs"}
+          p={"xs"}
+        />
+        </Box>
+        <Center fontSize={"lg"} pb={"sm"} pr={"lg"}>{count}</Center>
+      </HStack>
+    </Box>
+  );
+};
+
+export default FavoriteButton;

--- a/src/app/_components/postCard/postCard.tsx
+++ b/src/app/_components/postCard/postCard.tsx
@@ -8,6 +8,7 @@ import {
   Spacer,
   Box,
   Text,
+  Tag
 } from "@yamada-ui/react";
 import { HeartIcon } from "@yamada-ui/lucide";
 import { type Article } from "@/types/post";
@@ -47,9 +48,14 @@ export function PostCard({ post }: CardProps) {
         <CardFooter>
           <Flex gap="md">
             {post.tags.map((tag) => (
-              <Card key={tag.id} paddingInline="sm" bgColor={"neutral.50"}>
+              <Tag
+                key={tag.id}
+                paddingInline="sm"
+                bgColor={"neutral.50"}
+                color={"black"}
+              >
                 {tag.name}
-              </Card>
+              </Tag>
             ))}
           </Flex>
           <Spacer />

--- a/src/app/_testData/index.ts
+++ b/src/app/_testData/index.ts
@@ -30,14 +30,11 @@ const testMd = `
 `;
 
 const testMarp = `
----
-marp: true
-theme: default
-paginate: true
----
+<!-- marp: true -->
+<!-- theme: default -->
+<!-- paginate: true -->
 
 # 猫の可愛さについて
-
 ---
 
 ## 猫の特徴
@@ -78,11 +75,28 @@ paginate: true
 
 export const testPostData = {
   id: 1,
+  create_user_id: "387a4e2d-5b8d-4d-9035-ee95680b66b4",
   user_name: "usr_name",
   user_icon:
     "https://lh3.googleusercontent.com/a/ACg8ocKbLTbImuR5zomWyqMHS79Yk2T7-ypmnS1-hjF6MZX8Wtn1C6M=s96-c",
-  md: testMd,
-  marp: testMarp,
+  title: "猫の可愛さについて",
+  main_MD: testMd,
+  slide_MD: testMarp,
+  created_at: "2021-01-01T00:00:00Z",
+  updated_at: "2021-01-01T00:00:00Z",
+  like_count: 7,
+  public: true,
+  qiita_article: true,
+  tags: [
+    {
+      id: "1",
+      name: "tag1",
+    },
+    {
+      id: "2",
+      name: "tag2",
+    },
+  ],
 };
 
 export const testPostData2 = [

--- a/src/app/posts/post_id/page.tsx
+++ b/src/app/posts/post_id/page.tsx
@@ -60,7 +60,7 @@ const PostView = () => {
         </VStack>
       </HStack>
       {isMarkdownView ? (
-        <Box p={"xl"} bgColor={"whiteAlpha.950"}>
+        <Box p={"xl"} bgColor={"whiteAlpha.950"} rounded={"lg"}>
           <MarkdownPreview md={post.main_MD} />
         </Box>
       ) : (

--- a/src/app/posts/post_id/page.tsx
+++ b/src/app/posts/post_id/page.tsx
@@ -1,30 +1,70 @@
 "use client";
 import React, { useState } from "react";
 import MdSlideToggle from "@/app/_components/mdToSlide/MdSlideToggle";
-import { Box, Flex, Spacer } from "@yamada-ui/react";
+import { Box, Flex, Avatar, Text, Tag, Center, VStack, HStack } from "@yamada-ui/react";
 import MarkdownPreview from "@/app/_components/markdown/MarkdownPreview";
 import { testPostData } from "@/app/_testData";
 import SlidePreview from "@/app/_components/slide/SlidePreview";
+import FavoriteButton from "@/app/_components/favoriteButton/favoriteButton";
+
 const PostView = () => {
   // 仮置きデータ
   const post = testPostData;
 
   const [isMarkdownView, setIsMarkdownView] = useState(true);
+
+  const created_date: Date = new Date(post.created_at);
+  const date: string =
+    created_date.getUTCFullYear() +
+    "年" +
+    (created_date.getUTCMonth() + 1) +
+    "月" +
+    created_date.getUTCDate() +
+    "日";
+
   return (
-    <Box p={"lg"}>
-      <Flex>
-        <Spacer />
-        <MdSlideToggle
-          isMarkdownView={isMarkdownView}
-          setIsMarkdownView={setIsMarkdownView}
-        />
-      </Flex>
+    <Box paddingInline="9%" paddingTop={"lg"}>
+      <HStack marginInline={"xl"} mb={"md"}>
+        <VStack m={"xs"} gapY={"md"}>
+          <Flex>
+            <Avatar size="sm" name={post.user_name} src={post.user_icon} />
+            <Center fontSize={"lg"} paddingInline={"sm"}>
+              {post.user_name}
+            </Center>
+          </Flex>
+          <Text fontSize="4xl" fontWeight={"bold"}>
+            {post.title}
+          </Text>
+          <Flex gap="md">
+            {post.tags.map((tag) => (
+              <Tag
+                key={tag.id}
+                paddingInline="sm"
+                bgColor={"neutral.50"}
+                color={"black"}
+              >
+                {tag.name}
+              </Tag>
+            ))}
+          </Flex>
+          <Text>投稿日：{date}</Text>
+        </VStack>
+        <VStack gapY={"xl"} align={"end"} flex={"end"} pt={"xl"}>
+          <FavoriteButton countFavorite={post.like_count} />
+          <Box>
+            <MdSlideToggle
+              isMarkdownView={isMarkdownView}
+              setIsMarkdownView={setIsMarkdownView}
+            />
+          </Box>
+        </VStack>
+      </HStack>
       {isMarkdownView ? (
-        <Box p={"md"}>
-          <MarkdownPreview md={post.md} />
+        <Box p={"xl"} bgColor={"whiteAlpha.950"}>
+          <MarkdownPreview md={post.main_MD} />
         </Box>
       ) : (
-        <SlidePreview slide={post.marp} />
+        <SlidePreview slide={post.slide_MD} />
       )}
     </Box>
   );


### PR DESCRIPTION
close [#5 ](https://github.com/watagassa/md2s/issues/5)

## やったこと
- 仮データのmarpのmarkdownを修正した
- _testDataのtestPostDataの中のデータをtestPostDataのように全て揃える形に修正した
- posts/[post_id]のmarkdownの本文の背景をwhiteAlpha950に修正
- tagに前まではCardコンポーネントを使っていたが、Tagコンポーネントに変更したため、tagの箇所全てTagコンポーネントに修正した
- いいねボタンを実装した
- ユーザーアイコン、ユーザー名、タイトル、タグ、投稿日の表示部分の作成

## 修正した方がいいと思うところ
- ボタンのデザインがダサい