### PR TITLE
#36 feat-user-api

### DIFF
--- a/src/app/_testData/index.ts
+++ b/src/app/_testData/index.ts
@@ -90,18 +90,18 @@ export const testPostData = {
   tags: [
     {
       id: "1",
-      name: "tag1",
+      word: "tag1",
     },
     {
       id: "2",
-      name: "tag2",
+      word: "tag2",
     },
   ],
 };
 
 export const testPostData2 = [
   {
-    id: "1",
+    id: 1,
     create_user_id: "387a4e2d-5b8d-4d-9035-ee95680b66b4",
     user_name: "user1",
     user_icon: "/usr_icon.png",
@@ -115,17 +115,17 @@ export const testPostData2 = [
     qiita_article: true,
     tags: [
       {
-        id: "1",
-        name: "tag1",
+        id: 1,
+        word: "tag1",
       },
       {
-        id: "2",
-        name: "tag2",
+        id: 2,
+        word: "tag2",
       },
     ],
   },
   {
-    id: "2",
+    id: 2,
     create_user_id: "387a4e2d-5b8d-4d-9035-ee95680b66b4",
     user_name: "user2",
     user_icon: "/usr_icon.png",
@@ -139,17 +139,17 @@ export const testPostData2 = [
     qiita_article: false,
     tags: [
       {
-        id: "1",
-        name: "tag1",
+        id: 1,
+        word: "tag1",
       },
       {
-        id: "2",
-        name: "tag2",
+        id: 2,
+        word: "tag2",
       },
     ],
   },
   {
-    id: "3",
+    id: 3,
     create_user_id: "387a4e2d-5b8d-4d-9035-ee95680b66b4",
     user_name: "user2",
     user_icon: "/usr_icon.png",
@@ -163,12 +163,12 @@ export const testPostData2 = [
     qiita_article: false,
     tags: [
       {
-        id: "1",
-        name: "tag1",
+        id: 1,
+        word: "tag1",
       },
       {
-        id: "2",
-        name: "tag2",
+        id: 2,
+        word: "tag2",
       },
     ],
   },
@@ -179,6 +179,7 @@ export const testUserData = {
   name: "user1",
   icon: "/usr_icon.png",
   google_id: "151916161991",
+  qiita_link: false,
   total_posts_articles: 3,
   total_get_likes: 10,
 };

--- a/src/app/api/user/user.tsx
+++ b/src/app/api/user/user.tsx
@@ -1,5 +1,7 @@
+import { User } from "@/types/user";
 import { Session } from "next-auth";
 
+//ユーザー登録 API
 export const postUser = async (session: Session | null) => {
   const postAPI = process.env.NEXT_PUBLIC_API_URL + "/users";
   const name = session?.user?.name;
@@ -22,5 +24,37 @@ export const postUser = async (session: Session | null) => {
 
     const data = await res.json();
     console.log(data);
+  }
+};
+
+//ユーザー(自分)取得 API
+export const getUser = async (session: Session | null): Promise<User | null> => {
+  const getAPI = process.env.NEXT_PUBLIC_API_URL + "/users";
+  try {
+    if (session?.idToken) {
+      const res = await fetch(getAPI, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.idToken}`,
+        },
+      });
+
+      if (!res.ok) {
+        console.error(`Failed to get user: ${res.status}`);
+        return null;
+      }
+
+      const data: User = await res.json();
+      console.log(data);
+      return data;
+    }else{
+      console.log("session?.idTokenが受け取れませんでした.");
+      return null;
+    }
+
+  } catch (error) {
+    console.log("Error getting user:", error);
+    return null;
   }
 };

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -13,17 +13,23 @@ import {
   HStack,
   SkeletonCircle,
   SkeletonText,
+  Center,
+  Button,
 } from "@yamada-ui/react";
 import { useSession } from "next-auth/react";
 import { getUser } from "../api/user/user";
 import { User } from "@/types/user";
+import { Article } from "@/types/post";
+import { getUserArticles } from "../api/article/article";
+import { redirect } from "next/navigation";
 
 const page = () => {
-  const posts = testPostData2; //取得したユーザーが投稿した記事データ
+  // const posts = testPostData2; //取得したユーザーが投稿した記事データ
   // const user = testUserData; //取得したユーザーデータ
 
-  const { data: session, status }= useSession();
-  const [user, setUser] = useState<User | null>(null);
+  const { data: session, status } = useSession();
+  const [user, setUser] = useState<User | null>(null); //取得したユーザーデータ
+  const [posts, setPosts] = useState<Article[] | null>(null); //取得したユーザーが投稿した記事データ
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -34,6 +40,19 @@ const page = () => {
     fetchUser();
   }, [session]);
 
+  useEffect(() => {
+    const fetchUser = async () => {
+      if(user?.id != null){
+        const userResult = await getUserArticles(user?.id);
+        setPosts(userResult); // User | null を直接セット
+      }else{
+        console.log("user.idが取得できませんでした。")
+        setPosts(null);
+      }
+    };
+
+    fetchUser();
+  }, [session]);
 
   return (
     <Box bgColor={"blackAlpha.50"} py={"md"}>
@@ -58,7 +77,7 @@ const page = () => {
               <SkeletonText />
               <HStack pt={"md"}>
                 {/* TODO:user名が伸びると下の二つの要素の間が離れていくの修正できたらいいね... */}
-                <SkeletonText/>
+                <SkeletonText />
                 <Spacer />
                 <SkeletonText />
               </HStack>
@@ -71,11 +90,22 @@ const page = () => {
           投稿した記事
         </Text>
       </Flex>
-      <VStack gap={"md"}>
-        {posts.map((post) => (
-          <PostCard key={post.id} post={post} />
-        ))}
-      </VStack>
+      {posts != null ? (
+        <VStack gap={"md"}>
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </VStack>
+      ) : (
+        <Center>
+          <VStack gapY={"2xl"} margin={"xl"} >
+            <Text textAlign={"center"}>まだ投稿がありません。</Text>
+            <Button colorScheme="link" onClick={() => redirect("/posts/new")} h={"sm"} marginInline={"3xl"} fontSize={"8xl"}>
+              投稿する
+            </Button>
+          </VStack>
+        </Center>
+      )}
     </Box>
   );
 };

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -1,27 +1,70 @@
-import React from "react";
+"use client"
+
+import React, { useState, useEffect } from "react";
 import { testPostData2, testUserData } from "@/app/_testData";
 import { PostCard } from "@/app/_components/postCard/postCard";
-import { Box, VStack, Avatar, Flex, Text, Spacer, HStack } from "@yamada-ui/react";
+import {
+  Box,
+  VStack,
+  Avatar,
+  Flex,
+  Text,
+  Spacer,
+  HStack,
+  SkeletonCircle,
+  SkeletonText,
+} from "@yamada-ui/react";
+import { useSession } from "next-auth/react";
+import { getUser } from "../api/user/user";
+import { User } from "@/types/user";
 
 const page = () => {
   const posts = testPostData2; //取得したユーザーが投稿した記事データ
-  const user = testUserData; //取得したユーザーデータ
+  // const user = testUserData; //取得したユーザーデータ
+
+  const { data: session, status }= useSession();
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const userResult = await getUser(session);
+      setUser(userResult); // User | null を直接セット
+    };
+
+    fetchUser();
+  }, [session]);
+
 
   return (
     <Box bgColor={"blackAlpha.50"} py={"md"}>
       <Flex justify="center" m={"normal"}>
-        <Flex w="max(50%, sm)" p={"normal"} bgColor={"whiteAlpha.950"}>
-          <Avatar size="xl" name={user.name} src={user.icon} />
-          <Box px={"lg"}>
-            <Text fontSize={"3xl"}>{user.name}</Text>
-            <HStack  pt={"md"}>
-              {/* TODO:user名が伸びると下の二つの要素の間が離れていくの修正 */}
-              <Text>投稿数：{user.total_posts_articles}</Text>
-              <Spacer />
-              <Text>獲得いいね数：{user.total_get_likes}</Text>
-            </HStack>
-          </Box>
-        </Flex>
+        {user != null ? (
+          <Flex w="max(50%, sm)" p={"normal"} bgColor={"whiteAlpha.950"}>
+            <Avatar size="xl" name={user.name} src={user.icon_url} />
+            <Box px={"lg"}>
+              <Text fontSize={"3xl"}>{user.name}</Text>
+              <HStack pt={"md"}>
+                {/* TODO:user名が伸びると下の二つの要素の間が離れていくの修正できたらいいね... */}
+                <Text>投稿数：{user.total_posts_articles}</Text>
+                <Spacer />
+                <Text>獲得いいね数：{user.total_get_likes}</Text>
+              </HStack>
+            </Box>
+          </Flex>
+        ) : (
+          <Flex w="max(50%, sm)" p={"normal"} bgColor={"whiteAlpha.950"}>
+            <SkeletonCircle size="xl" />
+            <Box px={"lg"}>
+              <SkeletonText />
+              <HStack pt={"md"}>
+                {/* TODO:user名が伸びると下の二つの要素の間が離れていくの修正できたらいいね... */}
+                <SkeletonText/>
+                <Spacer />
+                <SkeletonText />
+              </HStack>
+            </Box>
+          </Flex>
+        )}
       </Flex>
       <Flex justify="center">
         <Text w="max(80%, sm)" p={"md"} fontSize={"lg"}>

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,5 +1,5 @@
 export interface Tag {
-  id: string;
+  id: number;
   word: string;
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,7 @@
+import { UUID } from "crypto";
+
 export interface User {
-  id: string;
+  id: UUID;
   name: string;
   icon_url: string;
   google_id: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,7 +1,7 @@
 export interface User {
   id: string;
   name: string;
-  icon: string;
+  icon_url: string;
   google_id: string;
   qiita_link: boolean;
   total_posts_articles: number;


### PR DESCRIPTION
close?[#36 ](https://github.com/watagassa/md2s/issues/36)

## コンフリクトが起こるってこと...!?
<img width="212" alt="スクリーンショット 2024-12-08 5 30 01" src="https://github.com/user-attachments/assets/4942caec-2a92-402c-a225-adb8cfedf8d3">

## やったこと
### feat: userページにてuser情報の取得ロジック実装
- Tag,Userの型を最新版に修正
- ユーザー(自分)取得API用関数実装
- サンプルデータを最新版に修正
- userページのuser情報をAPIから取得し、表示するようにした

### feat: userページでAPIから取得したユーザーの記事を表示する機能の実装
- userの型をstringからuuidに変更
- userページでAPIから取得したユーザーの記事を表示する機能を実装

## まだできてないこと
- 記事を選択したときに、編集ページに飛べるようにする